### PR TITLE
グループ一覧のアイコンと名前のずれを修正

### DIFF
--- a/php/group_list.php
+++ b/php/group_list.php
@@ -52,7 +52,7 @@ $groupId = $_GET['groupid'];
                 foreach ($member as $mem) {
                 ?>
                     <input id="acd-check<?= $cnt ?>" class="acd-check" type="checkbox">
-                    <label class="acd-label" for="acd-check<?= $cnt ?>"><img class="img-icon" src="../static/user.png"><?= $mem['name'] ?></label>
+                    <label class="acd-label" for="acd-check<?= $cnt ?>"><img class="img-icon" src="../static/user.png"><br><?= $mem['name'] ?></label>
                     <div class="acd-content">
                         <a href="" class="member-profile">プロフィールを見る</a>
                         <!--名前タップで「プロフィールを見る」を開く-->


### PR DESCRIPTION
グループ一覧のアイコンと名前のずれがあったので直しただけです（4文字だけ）