### PR TITLE
home.php group.phpの追加された交換会遷移ボタンが遷移出来るようにしました。

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -15,7 +15,7 @@
 }
 
 .home_groupname {
-    width: calc(100% - 160px);
+    width: calc(100% - 360px);
     margin: 0;
     margin-left: 20px;
     font-size: 60px;

--- a/css/home.css
+++ b/css/home.css
@@ -78,7 +78,6 @@
 .trade_look{
     display: inline-block;
     padding: 30px 0;
-    margin: 30px 0;
     width: 200px;
     border: 1px solid grey;
     border-radius: 10px;

--- a/php/classes/trade.php
+++ b/php/classes/trade.php
@@ -38,7 +38,7 @@
                     from trade
                     where group_id = ?';
             $stmt = $this->query($sql, [$group_id]);
-            $items = $stmt->fetch();
+            $items = $stmt->fetchAll();
             return $items;
         }
 

--- a/php/exchange_hold.php
+++ b/php/exchange_hold.php
@@ -10,14 +10,11 @@ $group = new GroupDetail();
 
 // メッセージの初期化
 $msg = "";
+// 交換会開催中フラグ
+$holding_flag = false;
 
-// セッションからユーザーIDとグループIDを取得し、グループIDのみ破棄（#2以降で修正）
-// $userId = $_SESSION['uid'];
-// $groupId = $_SESSION['groupId'];
-// unset($_SESSION['groupId']);
-
-// #1段階では、グループIDは固定値
-$groupId = 1;
+// グループIDを取得
+$groupId = $_GET['group_id'];
 // グループIDがあるか確認
 if (empty($groupId)) {
     $msg = "このグループでは<br>交換会を開催することは<br>出来ません。";
@@ -25,14 +22,19 @@ if (empty($groupId)) {
 
 // tradeテーブルに情報があるか、グループIDで確認
 $tradeInfo = $trade->gettradeInfo($groupId);
+$current_date = date("Y-m-d");
+if(!empty($tradeInfo)){
+    foreach ($tradeInfo as $eachtradeInfo){
+        // 現在の日付から交換会が開催期間中か判定
+        if($eachtradeInfo['begin_date'] <= $current_date && $current_date <= $eachtradeInfo['end_date']){
+            $holding_flag = true;
+            break;
+        }
+    }
+}
 
-// 過去の交換会情報が無い場合（交換会が開催出来る場合）
-if (empty($tradeInfo)) {
-    // // 現在の日付が、開催期間であるか
-    // $current_date = date("Y-m-d");
-    // if($tradeInfo['begin_date'] <= $current_date && $current_date <= $tradeInfo['end_date']){
-    //     $msg = '現在このグループでは交換会が開催されており、<br>新たに開催することは出来ません。';
-    // }
+// 交換会が開催出来る場合
+if (!$holding_flag) {
     // 開催するボタンが押されたとき
     if (isset($_POST['hold'])) {
         // 交換会名前と終了日を格納
@@ -96,6 +98,7 @@ if (empty($tradeInfo)) {
     if (!empty($msg)) { ?>
         <div class="prompt_2">
             <h4 class="msg-size"><?php echo $msg; ?></h4>
+            <a href="home.php">ホームに戻る</a>
         </div>
     <?php } else { ?>
 
@@ -115,7 +118,7 @@ if (empty($tradeInfo)) {
                 <div id="sub-form">
                     <p>交換会で交換する物のテーマを入力してください（最大3つ）</p>
                     <div id="inputArea">
-                        <input type="text" name="theme[]" class="exchange-theme-area" placeholder="3000円以下、身に着けるもの、季節もの 等" maxlength="30">
+                        <input type="text" name="theme[]" class="exchange-theme-area" placeholder="（例）3000円以下、身に着けるもの、季節もの 等" maxlength="30">
                         <button type="button" id="add" class="exchanege-theme-button">追加</button>
                         <button type="button" id="del" class="exchanege-theme-button">削除</button>
                     </div>

--- a/php/exchange_hold.php
+++ b/php/exchange_hold.php
@@ -64,7 +64,7 @@ if (!$holding_flag) {
 
         // tradeテーブルに追加出来たか判定
         if (!empty($trade_id)) {
-            // #2では交換会詳細画面に遷移する
+            // 交換会詳細画面に遷移する
             $url = "tradeinfo.php?trade_id=" . $trade_id;
             header("Location:" . $url);
             exit;

--- a/php/group.php
+++ b/php/group.php
@@ -1,15 +1,24 @@
 <?php
 require_once __DIR__ . '/header.php';
+require_once __DIR__ . '/classes/trade.php';
+$trade = new Trade();
 
 $userId = $_SESSION['uid'];
-/* if($_SERVER["REQUEST_METHOD"] === "POST"){
-    $groupid = $_POST['groupid'];
-}else{ */
 $groupId = $_GET['groupid'];
-// 交換会の為に、グループIDをセッションに保存
-$_SESSION['groupId'] = $groupId;
-/* }  */
 
+// トレードIDから交換会の情報を取得
+$tradeInfo = $trade->gettradeInfo($groupId);
+$current_date = date("Y-m-d");
+if(!empty($tradeInfo)){
+    // 所属しているグループごとで確認
+    foreach($tradeInfo as $eachtradeInfo){
+    // 現在の日付から交換会が開催期間中か判定
+    if($eachtradeInfo['begin_date'] <= $current_date && $current_date <= $eachtradeInfo['end_date']){
+        $tradeId = $eachtradeInfo['trade_id'];
+        break;
+    }
+} 
+}
 ?>
 <link rel="stylesheet" href="../css/group.css">
 </head>
@@ -17,7 +26,6 @@ $_SESSION['groupId'] = $groupId;
 <br>
 
 <!-- グループ名、各種ボタン -->
-
 <body>
 
 
@@ -80,15 +88,17 @@ $_SESSION['groupId'] = $groupId;
 
         <br>
         <br>
-        <a href="exchange_hold.php" class="hold-move-tag">
-            <p class="hold-move1">交換会を開催する<p>
-        </a>
+        <?php if(isset($tradeId)){ ?>
+            <a href="tradeinfo.php?trade_id=<?php echo $tradeId; ?>" class="hold-move-tag">
+                <p class="hold-move1">交換会開催中➣<p>
+            </a>
+        <?php }else{ ?>
+            <a href="exchange_hold.php?group_id=<?php echo $groupId; ?>" class="hold-move-tag">
+                <p class="hold-move1">交換会を開催する<p>
+            </a>
+        <?php } ?>
 
-        <a href="tradeinfo.php" class="hold-move-tag">
-            <p class="hold-move2">交換会開催中➣<p>
-        </a>
-
-        <?php
+        <?php 
         $cnt = 0;
         foreach ($gift_group_all as $gift_group) {
             echo '<div class="display" id=p' . $cnt . '>';

--- a/php/home.php
+++ b/php/home.php
@@ -1,7 +1,12 @@
 <?php
 require_once __DIR__ . '/header.php';
+// trade.phpを読み込み、トレードオブジェクトを生成
+require_once __DIR__ . '/classes/trade.php';
+$trade = new Trade();
 
 $userId = $_SESSION['uid'];
+
+// 交換会情報を取得する
 ?>
 <link rel="stylesheet" href="../css/home.css">
 <title>ホーム</title>
@@ -49,9 +54,27 @@ $userId = $_SESSION['uid'];
                     <div class="display">
                         <img class="home_groupicon" src="data:;base64,<?php echo $img; ?>">
                         <p class="home_groupname"><?= $join['groupname'] ?></p>
-                        <div class="trade_look_1">
-                            <a href="trade_origin.php?groupid=<?php echo $join['group_id']; ?>" class=trade_look>交換会<br>ページへ</a>
-                        </div>
+                        <?php
+                            // トレードIDから交換会の情報を取得
+                            $tradeInfo = $trade->gettradeInfo($join['group_id']);
+                            $current_date = date("Y-m-d");
+                            // 所属しているグループごとで確認
+                            foreach($tradeInfo as $eachtradeInfo){
+                                // 現在の日付から交換会が開催期間中か判定
+                                if($eachtradeInfo['begin_date'] <= $current_date && $current_date <= $eachtradeInfo['end_date']){
+                                    $tradeId = $eachtradeInfo['trade_id'];
+                                    break;
+                                }
+                            } 
+                            // 開催期間中なら交換会ページ（tradeinfo.php）に遷移するボタンを表示
+                            if(isset($tradeId)){ ?>
+                                <div class="trade_look_1">
+                                    <a href="tradeinfo.php?trade_id=<?php echo $tradeId; ?>" class=trade_look>交換会<br>ページへ</a>
+                                </div>
+                            <?php 
+                                // 交換会のトレードIDを破棄
+                                unset($tradeId); 
+                            } ?>
                     </div>
                     <?php // ギフトが送られているか判定・・・B
                     $gift_group = $group->giftgroup((int)$join['group_id'], $userId);

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -41,12 +41,12 @@
     $theme_array = array();
     if(isset($trade_info['theme1'])){
         array_push($theme_array, $trade_info['theme1']);
-        if(isset($trade_info['theme2'])){
-            array_push($theme_array, $trade_info['theme2']);
-            if(isset($trade_info['theme3'])){
-                array_push($theme_array, $trade_info['theme3']);
-            }
-        }
+    }
+    if(isset($trade_info['theme2'])){
+        array_push($theme_array, $trade_info['theme2']);
+    }
+    if(isset($trade_info['theme3'])){
+            array_push($theme_array, $trade_info['theme3']);
     }
 
     // 交換会の説明文と説明文のバイト数を変数に追加

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -65,6 +65,9 @@
 
         // trade_goodsテーブルに追加
         $trade->postGoods($trade_id, $userid, $goods_name, $goods_hint, $image);
+        $url = "tradeinfo.php?trade_id=" . $trade_id;
+        header("Location:" . $url);
+        exit;
     }
 
 ?>


### PR DESCRIPTION
**確認して欲しい事項**

- [x] home.php で交換会開催中のグループならば、「交換会ページへ」のボタンが表示されているか
- [x]  「交換会ページへ」を押した時、正しい交換会詳細（tradeinfo.php）に遷移するか
- [ ]　グループＩＤは正しくても、交換会期間でないならば「交換会ページへ」は非表示になっているか
- [x] group.phpで「交換会開催中」と「交換会を開催する」の2つのボタンが、データベースの状況に応じて表示されているか
- [x] 上記の「交換会開催中」と「交換会を開催する」の2つのボタンの遷移先があっているか（交換会開催中→tradeinfo.php・交換会を開催する→exchange_hold.php）

その他エラー表示・分岐忘れがあるかもしれないので、おかしな表示や意図しない動作があればコメントよろしくお願いしますm(__)m