### PR TITLE
交換会の期限終了後、交換がまだ実施されていない時のエラーメッセージを追加しました。

### DIFF
--- a/css/tradeinfo.css
+++ b/css/tradeinfo.css
@@ -300,7 +300,7 @@
 
 /* 交換会終了後の表示 */
 .after-trade{
-    margin-top: 250px;
+    margin-top: 150px;
     margin-bottom: 150px;
     font-size: 40px;
     text-align: center;

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -177,11 +177,19 @@
                     $pass_info = $trade->passGoodsInfo($userid, $trade_id);
                     $receive_info = $trade->receiveGoodsInfo($userid, $trade_id);
 
-                    $pass_image = base64_encode($pass_info['goods_image']);
-                    $pass_icon = base64_encode($pass_info['icon']);
+                    // 交換会終了後、交換が実施されていない場合の処理
+                    if((empty($pass_info)) || (empty($receive_info))){ ?>
+                        <div class="after-trade">
+                            <div class="prompt_2">
+                                <h4 class="msg-size">交換を実施中。<br>交換物発表までもうしばらくお待ちください。</h4>
+                            </div>
+                        </div>
+                    <?php }else{ 
+                        $pass_image = base64_encode($pass_info['goods_image']);
+                        $pass_icon = base64_encode($pass_info['icon']);
 
-                    $receive_image = base64_encode($receive_info['goods_image']);
-                    $receive_icon = base64_encode($receive_info['icon']);
+                        $receive_image = base64_encode($receive_info['goods_image']);
+                        $receive_icon = base64_encode($receive_info['icon']);
                 ?>
                 <!-- 交換会終了後の表示 -->
                 <div class="after-trade">
@@ -219,7 +227,7 @@
                 </div>
               
             <!-- 交換会が開催期間内の場合 -->
-            <?php } }else{ ?>
+            <?php } } }else{ ?>
                 <!-- まだログインしているユーザーが交換会に参加していない場合 -->
                 <?php if(empty($post_goods_info)){ ?>
                     <form method="POST" action="" class="trade-form" enctype="multipart/form-data">


### PR DESCRIPTION
**確認手順**

1. 開催期間が終了している交換会で、3人以上交換物を投稿・参加している状態にする。
2. trade_goodsテーブルで投稿しているグッズのreceive_idをNULLにする。

**確認事項**

- [ ] receive_idがNULLであれば、エラーメッセージが表示されるか
- [ ] 一部だけreceive_idを入力しても、エラーメッセージが表示されるか
- [ ] エラーメッセージが表示されず、交換物の情報が表示されることはないか