### PR TITLE
自分以外の交換会の受け渡し情報を追加しました。

### DIFF
--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -1,0 +1,68 @@
+.other-trade-info{
+    margin-top: 135px;
+}
+
+.each-flex{
+    display: flex;
+    justify-content: center;
+}
+
+.user-icon{
+    display: flex;
+    align-items: center;
+    margin: 30px;
+}
+
+.goods-image{
+    width: 30%;
+}
+
+.icon-size{
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 100%;
+    border: solid 1px gray;
+}
+
+.square{
+    justify-content: flex-end;
+    width: 150px;
+	height: 60px;
+	background: #0091EA;
+}
+
+.image-size{
+    width: 100%;
+    object-fit: cover;
+    aspect-ratio: 1 / 1;
+    border-radius: 10px;
+    border: 1px solid grey;
+}
+
+.goods-name{
+    height: 90px;
+    font-size: 30px;
+    border-radius: 0 0 10px 10px;
+    border: 1px solid gray;
+    display: flex;
+    align-items: center;
+    margin-top: -5px;
+}
+
+.name-size {
+    text-align: center;
+    width: 100%;
+    padding: 0 50px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.border{
+    width: calc(100% - 40px);
+    margin: 0 auto;
+    border: none;
+    background: grey;
+    height: 1px;
+}

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -20,6 +20,10 @@
     margin-top: 30px;
 }
 
+.no-hint{
+    align-items: center;
+}
+
 .goods-image{
     position: relative;
     justify-content: center;

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -16,7 +16,8 @@
     position: relative;
     justify-content: center;
     width: 35%;
-    align-items: center;
+    /* align-items: center; */
+    margin-top: 30px;
 }
 
 .goods-image{

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -20,7 +20,10 @@
 }
 
 .goods-image{
+    position: relative;
+    justify-content: center;
     width: 30%;
+    align-items: center;
 }
 
 .icon-size{
@@ -42,6 +45,7 @@
     color: #555;
     font-size: 16px;
     background: #e0edff;
+    margin: 10px;
 }
   
 .balloon1-top:before {
@@ -56,8 +60,9 @@
   
 .balloon1-top p {
     font-size: 32px;
+    word-wrap: break-word;
     margin: 0;
-    padding: 0;
+    padding: 0 5px;
 }
 
 /* .square{
@@ -92,6 +97,7 @@
     aspect-ratio: 1 / 1;
     border-radius: 10px;
     border: 1px solid grey;
+    margin-bottom: -5px;
 }
 
 .goods-name{
@@ -101,7 +107,7 @@
     border: 1px solid gray;
     display: flex;
     align-items: center;
-    margin-top: -5px;
+    margin-top: -10px;
 }
 
 .name-size {

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -7,8 +7,13 @@
     justify-content: center;
 }
 
+.pass-info{
+    text-align: center;
+}
+
 .user-icon{
     display: flex;
+    position: relative;
     justify-content: center;
     width: 35%;
     align-items: center;
@@ -26,14 +31,62 @@
     border: solid 1px gray;
 }
 
-.square{
+/* 吹き出し */
+.balloon1-top {
+    position: relative;
+    display: flex;
+    margin: 1.5em 0;
+    padding: 7px 10px;
+    min-width: 120px;
+    max-width: 100%;
+    color: #555;
+    font-size: 16px;
+    background: #e0edff;
+}
+  
+.balloon1-top:before {
+    content: "";
+    position: absolute;
+    top: -30px;
+    left: 50%;
+    margin-left: -15px;
+    border: 15px solid transparent;
+    border-bottom: 15px solid #e0edff;
+}
+  
+.balloon1-top p {
+    font-size: 32px;
+    margin: 0;
+    padding: 0;
+}
+
+/* .square{
     justify-content: flex-end;
     width: 150px;
 	height: 60px;
 	background: #0091EA;
+} */
+
+/* 矢印 */
+.arrow1 {
+    position: relative; /*ボックスの位置指定 */
+    width: 100%; /* ボックスの横幅を指定する */
+    height: 20px; /* ボックスの高さを指定する */
+    background: #666666;/* ボックスの背景色を指定する */
+    margin-bottom: 10px;
+}
+.arrow1:after{
+    position: absolute; /* 三角形の位置指定 */
+    content: ""; /* 三角形のコンテンツ */
+    top: -10px; /* 上部から配置の基準位置を決める */
+    right: -40px; /* 右から配置の基準位置を決める */
+    border:20px solid; /* 境界線を指定する */
+    border-color:transparent; /* 境界線の色をなしにする */
+    border-left: 20px solid #666666;/* 境界線の上部を実線で指定する */
 }
 
 .image-size{
+    position: relative;
     width: 100%;
     object-fit: cover;
     aspect-ratio: 1 / 1;

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -16,11 +16,14 @@
     position: relative;
     justify-content: center;
     width: 35%;
-    /* align-items: center; */
     margin-top: 30px;
 }
 
 .no-hint{
+    display: flex;
+    position: relative;
+    justify-content: center;
+    width: 35%;
     align-items: center;
 }
 
@@ -29,6 +32,11 @@
     justify-content: center;
     width: 30%;
     align-items: center;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
 }
 
 .icon-size{
@@ -53,7 +61,7 @@
     margin: 10px;
 }
   
-.balloon1-top:before {
+/* .balloon1-top:before {
     content: "";
     position: absolute;
     top: -30px;
@@ -61,7 +69,7 @@
     margin-left: -15px;
     border: 15px solid transparent;
     border-bottom: 15px solid #e0edff;
-}
+} */
   
 .balloon1-top p {
     font-size: 32px;
@@ -70,29 +78,24 @@
     padding: 0 5px;
 }
 
-/* .square{
-    justify-content: flex-end;
-    width: 150px;
-	height: 60px;
-	background: #0091EA;
-} */
 
 /* 矢印 */
 .arrow1 {
     position: relative; /*ボックスの位置指定 */
     width: 100%; /* ボックスの横幅を指定する */
-    height: 20px; /* ボックスの高さを指定する */
-    background: #666666;/* ボックスの背景色を指定する */
+    height: 50px; /* ボックスの高さを指定する */
+    /* background: #666666;ボックスの背景色を指定する */
     margin-bottom: 10px;
+    background-color: #668ad8;
 }
 .arrow1:after{
     position: absolute; /* 三角形の位置指定 */
     content: ""; /* 三角形のコンテンツ */
-    top: -10px; /* 上部から配置の基準位置を決める */
-    right: -40px; /* 右から配置の基準位置を決める */
-    border:20px solid; /* 境界線を指定する */
-    border-color:transparent; /* 境界線の色をなしにする */
-    border-left: 20px solid #666666;/* 境界線の上部を実線で指定する */
+    top: -30px; /* 上部から配置の基準位置を決める */
+    right: -70px; /* 右から配置の基準位置を決める */
+    /* border-color:transparent; 境界線の色をなしにする */
+    border-top: 80px solid transparent;
+    border-left: 70px solid #668ad8;
 }
 
 .image-size{
@@ -106,19 +109,19 @@
 }
 
 .goods-name{
-    height: 90px;
+    height: 50px;
     font-size: 30px;
     border-radius: 0 0 10px 10px;
-    border: 1px solid gray;
     display: flex;
     align-items: center;
-    margin-top: -10px;
+    color: #fefefe;
+    margin-top: -5px
 }
 
 .name-size {
     text-align: center;
     width: 100%;
-    padding: 0 50px;
+    padding: 0 30px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/css/trade_other.css
+++ b/css/trade_other.css
@@ -9,8 +9,9 @@
 
 .user-icon{
     display: flex;
+    justify-content: center;
+    width: 35%;
     align-items: center;
-    margin: 30px;
 }
 
 .goods-image{

--- a/js/tradeinfo-a.js
+++ b/js/tradeinfo-a.js
@@ -1,9 +1,12 @@
 p0.style.display ="block";
 p1.style.display ="none";
+p2.style.display = "none";
 b0.style.color ="black";
 b1.style.color ="gray";
+b2.style.color = "gray";
 b0.style.border ="2px black solid";
 b1.style.border ="2px gray solid";
+b2.style.border ="2px gray solid";
 // {
 //     const btn = document.getElementById('btn');
 //             btn.addEventListener('click', () => {
@@ -11,19 +14,35 @@ b1.style.border ="2px gray solid";
 //             })
 // }
 function click_list_event(i) {
-    if(i == 1) {
+    if(i == 0) {
         p0.style.display ="block";
         p1.style.display ="none";
+        p2.style.display = "none";
         b0.style.color ="black";
         b1.style.color ="gray";
-        b0.style.border ="2px black solid";
-        b1.style.border ="2px gray solid";
-    } else if(i == 2) {
+        p2.style.color = "gray";
+        b0.style.border = "2px black solid";
+        b1.style.border = "2px gray solid";
+        b2.style.border = "2px gray solid";
+    } else if(i == 1) {
         p0.style.display ="none";
         p1.style.display ="block";
+        p2.style.display = "none";
         b0.style.color ="gray";
         b1.style.color ="black";
+        b2.style.color = "gray";
         b0.style.border ="2px gray solid";
         b1.style.border ="2px black solid";
-    } 
+        b2.style.border = "2px glay solid";
+    } else if(i == 2){
+        p0.style.display = "none";
+        p1.style.display = "none";
+        p2.style.display = "block";
+        b0.style.color ="gray";
+        b1.style.color ="gray";
+        b2.style.color = "black";
+        b0.style.border ="2px gray solid";
+        b1.style.border ="2px gray solid";
+        b2.style.border ="2px black solid";
+    }
 }

--- a/php/classes/trade.php
+++ b/php/classes/trade.php
@@ -42,6 +42,16 @@
             return $items;
         }
 
+        // トレードIDからグッズの渡す人・貰う人のID、グッズ名、グッズ画像を取得する
+        public function otherTradeInfo($trade_id){
+            $sql = "select pass_id, goods_name, goods_image, receive_id
+                    from trade_goods
+                    where trade_id = ?";
+            $stmt = $this->query($sql, [$trade_id]);
+            $items = $stmt->fetchAll();
+            return $items;
+        }
+
         // トレードIDからグッズの情報（ヒントなど）を取得
         public function getGoodsInfo($trade_id){
             $sql = "select user.name, user.icon, trade_goods.goods_hint

--- a/php/classes/trade.php
+++ b/php/classes/trade.php
@@ -44,7 +44,7 @@
 
         // トレードIDからグッズの渡す人・貰う人のID、グッズ名、グッズ画像を取得する
         public function otherTradeInfo($trade_id){
-            $sql = "select pass_id, goods_name, goods_image, receive_id
+            $sql = "select pass_id, goods_name, goods_image, receive_id, goods_hint
                     from trade_goods
                     where trade_id = ?";
             $stmt = $this->query($sql, [$trade_id]);

--- a/php/trade_other.php
+++ b/php/trade_other.php
@@ -1,0 +1,52 @@
+<?php
+    // ヘッダーを読み込む
+    require_once __DIR__ . '/header.php';
+    // trade.phpを読み込み、トレードオブジェクトを生成
+    require_once __DIR__ . '/classes/trade.php';
+    $trade = new Trade();
+    // user.phpを読み込み、ユーザーオブジェクトを生成
+    require_once __DIR__ . '/classes/user.php';
+    $user = new User();
+
+    // セッションからログイン中のユーザーIDを取得する
+    $userid = $_SESSION['uid'];
+    // GETで表示するユーザーのIDを取得する
+    $trade_id = $_GET['trade_id'];
+
+    // 交換会ID（トレードID）から交換会へ出品されたグッズの情報を取得する
+    $other_trade_info = $trade->otherTradeInfo($trade_id);
+?>
+
+
+
+<link rel="stylesheet" href="../css/trade_other.css">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>別の交換</title>
+</head>
+<br>
+    <div class="other-trade-info">
+        <?php foreach($other_trade_info as $each_trade_info){ 
+            $goods_image = base64_encode($each_trade_info['goods_image']);
+            $pass_info = $user->getUser($each_trade_info['pass_id']);
+            $pass_icon = base64_encode($pass_info['icon']);
+            $receive_info = $user->getUser($each_trade_info['receive_id']);
+            $receive_icon = base64_encode($receive_info['icon']);
+            ?>
+            <div class="each-flex">
+                <div class="user-icon">
+                    <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                </div>
+                <div class="goods-image">
+                    <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
+                    <div class="goods-name">
+                        <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
+                    </div>
+                </div>
+                <div class="user-icon">
+                    <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
+                </div>
+            </div>
+            <hr class="notifi-border">
+        <?php } ?>
+    </div>
+</body>

--- a/php/trade_other.php
+++ b/php/trade_other.php
@@ -34,9 +34,15 @@
             ?>
             <div class="each-flex">
                 <div class="user-icon">
-                    <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                    <div class="pass-info">
+                        <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                        <div class="balloon1-top">
+                                <p>こんにちは。これは例です。</p>
+                        </div>
+                    </div>
                 </div>
                 <div class="goods-image">
+                    <div class="arrow1"></div>
                     <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
                     <div class="goods-name">
                         <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>

--- a/php/trade_other.php
+++ b/php/trade_other.php
@@ -36,14 +36,16 @@
                 <div class="user-icon">
                     <div class="pass-info">
                         <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
-                        <div class="balloon1-top">
-                                <p>こんにちは。これは例です。</p>
-                        </div>
+                        <?php if(isset($each_trade_info['goods_hint'])){ ?>
+                            <div class="balloon1-top">
+                                    <p>ヒント<br><?php echo $each_trade_info['goods_hint'] ?></p>
+                            </div>
+                        <?php } ?>
                     </div>
                 </div>
                 <div class="goods-image">
-                    <div class="arrow1"></div>
                     <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
+                    <div class="arrow1"></div>
                     <div class="goods-name">
                         <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
                     </div>

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -226,6 +226,7 @@
                     </div>
 
                     <div id="p2">
+                        <!-- 他メンバーの交換情報を取得 -->
                         <div class="other-trade-info">
                             <?php foreach($other_trade_info as $each_trade_info){ 
                                 $goods_image = base64_encode($each_trade_info['goods_image']);
@@ -234,19 +235,33 @@
                                 $receive_info = $user->getUser($each_trade_info['receive_id']);
                                 $receive_icon = base64_encode($receive_info['icon']);
                             ?>
+
+                            <!-- それぞれの交換情報を表示 -->
                             <div class="each-flex">
-                                <div class="user-icon">
-                                    <div class="pass-info">
-                                        <a href="user_profile.php?id=<?php echo $each_trade_info['pass_id']; ?>">
-                                            <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
-                                        </a>
-                                        <?php if(isset($each_trade_info['goods_hint'])){ ?>
-                                            <div class="balloon1-top">
-                                                <p>ヒント<br><?php echo $each_trade_info['goods_hint'] ?></p>
-                                            </div>
-                                        <?php } ?>
+                                <!-- 出品者がヒントを記入していた場合 -->
+                                <?php if(isset($each_trade_info['goods_hint'])){ ?>
+                                    <div class="user-icon">
+                                        <div class="pass-info">
+                                            <a href="user_profile.php?id=<?php echo $each_trade_info['pass_id']; ?>">
+                                                <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                                            </a>
+                                                <div class="balloon1-top">
+                                                    <p>ヒント<br><?php echo $each_trade_info['goods_hint'] ?></p>
+                                                </div>
+                                        </div>
                                     </div>
-                                </div>
+                                <!-- ヒントを記入していなかった場合 -->
+                                <?php }else{ ?>
+                                    <div class="user-icon no-hint">
+                                        <div class="pass-info">
+                                            <a href="user_profile.php?id=<?php echo $each_trade_info['pass_id']; ?>">
+                                                <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                                            </a>
+                                        </div>
+                                    </div>
+                                <?php } ?>
+
+                                <!-- 交換物の画像・矢印・名前を表示 -->
                                 <div class="goods-image">
                                     <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
                                     <div class="arrow1"></div>
@@ -254,11 +269,21 @@
                                         <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
                                     </div>
                                 </div>
-                                <div class="user-icon">
-                                    <a href="user_profile.php?id=<?php echo $each_trade_info['receive_id']; ?>">
-                                        <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
-                                    </a>
-                                </div>
+
+                                <!-- 貰う人のアイコンを表示 -->
+                                <?php if(isset($each_trade_info['goods_hint'])){ ?>
+                                    <div class="user-icon">
+                                        <a href="user_profile.php?id=<?php echo $each_trade_info['receive_id']; ?>">
+                                            <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
+                                        </a>
+                                    </div>
+                                <?php }else{ ?>
+                                    <div class="user-icon no-hint">
+                                        <a href="user_profile.php?id=<?php echo $each_trade_info['receive_id']; ?>">
+                                            <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
+                                        </a>
+                                    </div>
+                                <?php } ?>
                             </div>
                             <hr class="notifi-border">
                             <?php } ?>

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -264,10 +264,14 @@
                                 <!-- 交換物の画像・矢印・名前を表示 -->
                                 <div class="goods-image">
                                     <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
-                                    <div class="arrow1"></div>
-                                    <div class="goods-name">
-                                        <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
+                                    <div class="arrow1">
+                                        <div class="goods-name">
+                                            <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
+                                        </div>
                                     </div>
+                                    <!-- <div class="goods-name">
+                                        <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
+                                    </div> -->
                                 </div>
 
                                 <!-- 貰う人のアイコンを表示 -->
@@ -278,7 +282,7 @@
                                         </a>
                                     </div>
                                 <?php }else{ ?>
-                                    <div class="user-icon no-hint">
+                                    <div class="no-hint">
                                         <a href="user_profile.php?id=<?php echo $each_trade_info['receive_id']; ?>">
                                             <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
                                         </a>

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -7,6 +7,9 @@
     // groupdetail.phpを読み込み、グループディテールオブジェクトを生成
     require_once __DIR__ . '/classes/groupdetail.php';
     $groupdetail = new GroupDetail();
+    // user.phpを読み込み、ユーザーオブジェクトを生成
+    require_once __DIR__ . '/classes/user.php';
+    $user = new User();
 
     // エラーメッセージ
     $msg = '';
@@ -57,6 +60,9 @@
     // 現在ログインしているユーザーが交換物を投稿しているか情報を取得
     $post_goods_info = $trade->postGoodsInfo($userid, $trade_id);
 
+    // 交換会ID（トレードID）から交換会へ出品されたグッズの情報を取得する
+    $other_trade_info = $trade->otherTradeInfo($trade_id);
+
     // 交換会に参加・交換物を投稿
     if(isset($_POST['post_btn'])){
         // 画像の処理
@@ -82,6 +88,7 @@
 ?>
 
 <link rel="stylesheet" href="../css/tradeinfo.css">
+<link rel="stylesheet" href="../css/trade_other.css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title><?php echo $trade_info['trade_name']; ?></title>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
@@ -187,8 +194,9 @@
                 <div class="after-trade">
                     <div>
                         <div>
-                            <button class="btn-switch" id="b0" onclick="click_list_event(1)">貰う物・人</button>
-                            <button class="btn-switch" id="b1" onclick="click_list_event(2)">渡す物・人</button>
+                            <button class="btn-switch" id="b0" onclick="click_list_event(0)">貰う物・人</button>
+                            <button class="btn-switch" id="b1" onclick="click_list_event(1)">渡す物・人</button>
+                            <button class="btn-switch" id="b2" onclick="click_list_event(2)">その他</button>
                         </div>
                     </div>
 
@@ -215,6 +223,46 @@
                         <?php }elseif($receive_info['confirm'] == 1){ ?>
                             <button class="sending-confirmation">受け取り済み</button>
                         <?php } ?>
+                    </div>
+
+                    <div id="p2">
+                        <div class="other-trade-info">
+                            <?php foreach($other_trade_info as $each_trade_info){ 
+                                $goods_image = base64_encode($each_trade_info['goods_image']);
+                                $pass_info = $user->getUser($each_trade_info['pass_id']);
+                                $pass_icon = base64_encode($pass_info['icon']);
+                                $receive_info = $user->getUser($each_trade_info['receive_id']);
+                                $receive_icon = base64_encode($receive_info['icon']);
+                            ?>
+                            <div class="each-flex">
+                                <div class="user-icon">
+                                    <div class="pass-info">
+                                        <a href="user_profile.php?id=<?php echo $each_trade_info['pass_id']; ?>">
+                                            <img class="icon-size" src="data:;base64,<?php echo $pass_icon; ?>">
+                                        </a>
+                                        <?php if(isset($each_trade_info['goods_hint'])){ ?>
+                                            <div class="balloon1-top">
+                                                <p>ヒント<br><?php echo $each_trade_info['goods_hint'] ?></p>
+                                            </div>
+                                        <?php } ?>
+                                    </div>
+                                </div>
+                                <div class="goods-image">
+                                    <img class="image-size" src="data:;base64,<?php echo $goods_image; ?>">
+                                    <div class="arrow1"></div>
+                                    <div class="goods-name">
+                                        <p class="name-size"><?php echo $each_trade_info['goods_name']; ?></p>
+                                    </div>
+                                </div>
+                                <div class="user-icon">
+                                    <a href="user_profile.php?id=<?php echo $each_trade_info['receive_id']; ?>">
+                                        <img class="icon-size" src="data:;base64,<?php echo $receive_icon; ?>">
+                                    </a>
+                                </div>
+                            </div>
+                            <hr class="notifi-border">
+                            <?php } ?>
+                        </div>
                     </div>
                 </div>
               


### PR DESCRIPTION
開催期間が終了している交換会で、交換が終了した後の表示に他の人の受け渡し情報を追加しました。

**確認事項**

- [x] 開催期間が終了している交換会ページ（tradeinfo.php）で、「貰う物・人」「渡す物・人」以外に「その他」のタブが追加されているか
- [x] タブを切り替えると、タブ下記の表示が切り替わるか
- [x] データベース通りの交換情報になっているか
- [x] ヒントの文字数によって画面乱れなどはないか


ある程度の大きさの交換物の画像を表示させようと思ったら、渡す人・貰う人のアイコンの欄が寂しかったのでヒントを追加しました。
矢印の色とか表示方法、空白の使い方などコメント貰えれば嬉しいです。（自分のデザインセンスではこれが限界でした。）