### PR TITLE
交換会開催の終了日を自由に設定できるバックエンドを追加しました。

### DIFF
--- a/css/exchange_hold.css
+++ b/css/exchange_hold.css
@@ -169,7 +169,7 @@ input {
     height: 36px;
     border: 2px solid #ccc;
     border-radius: 20px;
-    font-size: 45px;
+    font-size: 32px;
 }
 
 /* エラーメッセージの表示 */

--- a/css/tradeinfo.css
+++ b/css/tradeinfo.css
@@ -2,8 +2,9 @@
     margin-top: 140px;
     font-size: 40px;
     padding: 40px;
+    -webkit-text-size-adjust: 100%;
 }
-.trade-info p{
+.display-date{
     font-size: 0.7em;
 }
 .trade-title{
@@ -12,6 +13,10 @@
 .trade-title h1{
     padding: 10px;
     word-break: break-all;
+}
+.date-title{
+    font-weight: bold;
+    font-size: 0.8em;
 }
 .participant{
     margin-top: 100px;
@@ -35,6 +40,9 @@
 }
 .trade-theme{
     margin-top: 80px
+}
+.trade-theme p{
+    font-size: 0.8em;
 }
 .trade-explain{
     margin-top: 80px;
@@ -121,7 +129,7 @@
 }
 /* 投稿フォーム */
 .trade-form{
-    margin-top: 250px;
+    margin-top: 180px;
     margin-bottom: 150px;
     font-size: 40px;
 }
@@ -213,7 +221,7 @@
     margin-top: 80px;
 }
 .form-box{
-    width: calc(100vw - 110px);
+    width: calc(100vw - 120px);
     border-radius: 20px;
     font-size: 1.0em;
     border: 1px solid gray;
@@ -247,7 +255,7 @@
     color: rgba(119, 29, 29, 0.534);
 }
 .msg-size {
-    height: 50px;
+    height: 42px;
     color: rgba(119, 29, 29, 0.534);
     text-align: center;
 }
@@ -405,11 +413,17 @@
     font-size: 50px;
     color: rgba(119, 29, 29, 0.534);
 }
+.no-participant{
+    padding: 0 20px;
+    text-align: center;
+    font-size: 50px;
+    color: rgba(119, 29, 29, 0.534);
+}
 .prompt_3 h4{
     overflow-wrap: break-word;
     word-break: break-all;
 }
 .prompt_3 a{
     color: blue;
-    font-size: 40px;
+    font-size: 42px;
 }

--- a/js/exchange_hold.js
+++ b/js/exchange_hold.js
@@ -57,15 +57,11 @@ window.addEventListener('DOMContentLoaded', function () {
 const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
 const now = Date.now();
 const today = new Date(now);
-const afterOneWeek = new Date(now + 1 * 7 * 24 * 60 * 60 * 1000); // 一週間後
-const afterTwoWeek = new Date(now + 2 * 7 * 24 * 60 * 60 * 1000); // 二週間後
-const afterThreeWeek = new Date(now + 3 * 7 * 24 * 60 * 60 * 1000); // 三週間後
-const afterOnemonth = new Date(now + 1 * 7 * 24 * 60 * 60 * 1000 * 4); // 一か月後
+const afterOneWeek = new Date(now + 1 * 7 * 24 * 60 * 60 * 1000 - 60 * 60 * 24 * 1000); // 一週間後
+const afterTwoWeek = new Date(now + 2 * 7 * 24 * 60 * 60 * 1000 - 60 * 60 * 24 * 1000); // 二週間後
+const afterThreeWeek = new Date(now + 3 * 7 * 24 * 60 * 60 * 1000 - 60 * 60 * 24 * 1000); // 三週間後
+const afterOnemonth = new Date(now + 1 * 7 * 24 * 60 * 60 * 1000 * 4 - 60 * 60 * 24 * 1000); // 一か月後
 const daycheck = new Date(now + document.getElementById("setDate").value);
-
-// const afterTwomonth = new Date(now + 2 * 7 * 24 * 60 * 60 * 1000 * 4); // 二か月後
-// const afterThreemonth = new Date(now + 3 * 7 * 24 * 60 * 60 * 1000 * 4); // 三か月後
-
 
 document.getElementById('today').textContent = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()} (${weekdays[today.getDay()]})`;
 document.getElementById('after1week').textContent = `${afterOneWeek.getFullYear()}/${afterOneWeek.getMonth() + 1}/${afterOneWeek.getDate()} (${weekdays[afterOneWeek.getDay()]})`;

--- a/php/exchange_hold.php
+++ b/php/exchange_hold.php
@@ -27,8 +27,8 @@ if (empty($groupId)) {
 $tradeInfo = $trade->gettradeInfo($groupId);
 $current_date = date("Y-m-d");
 // 終了期間自由選択の開始日、終了日を指定
-$onedaylater = date("Y-m-d", strtotime("+1 day"));
-$fourweekslater = date("Y-m-d",strtotime("+4 weeks -1day"));
+$onedaylater = date("Y-m-d", strtotime("+1 day", strtotime($current_date)));
+$fourweekslater = date("Y-m-d",strtotime("+4 weeks -1day", strtotime($current_date)));
 if (!empty($tradeInfo)) {
     foreach ($tradeInfo as $eachtradeInfo) {
         // 現在の日付から交換会が開催期間中か判定

--- a/php/exchange_hold.php
+++ b/php/exchange_hold.php
@@ -26,6 +26,9 @@ if (empty($groupId)) {
 // tradeテーブルに情報があるか、グループIDで確認
 $tradeInfo = $trade->gettradeInfo($groupId);
 $current_date = date("Y-m-d");
+// 終了期間自由選択の開始日、終了日を指定
+$onedaylater = date("Y-m-d", strtotime("+1 day"));
+$fourweekslater = date("Y-m-d",strtotime("+4 weeks -1day"));
 if (!empty($tradeInfo)) {
     foreach ($tradeInfo as $eachtradeInfo) {
         // 現在の日付から交換会が開催期間中か判定
@@ -43,6 +46,8 @@ if (!$holding_flag) {
         // 交換会名前と終了日を格納
         $trade_name = $_POST['trade_name'];
         $end_date = $_POST['end_date'];
+
+
         // 変数の初期化
         $trade_explain = NULL;
         $theme1 = $theme2 = $theme3 = NULL;
@@ -86,11 +91,8 @@ if (!$holding_flag) {
 
     // 過去の交換会情報がある場合
 } else {
-    $current_date = date("Y-m-d");
-    // 現在の日付が、開催期間であるか
-    if ($tradeInfo['begin_date'] <= $current_date && $current_date <= $tradeInfo['end_date']) {
-        $msg = '現在このグループでは<br>交換会が開催されており、<br>新たに開催することは出来ません。';
-    }
+    $msg = '現在このグループでは<br>交換会が開催されており、<br>新たに開催することは出来ません。';
+   
 }
 
 
@@ -161,7 +163,7 @@ if (!$holding_flag) {
                 <!-- 終了日入力 -->
                 <div>
                     <p class="exchange-finish">交換会の終了日</p>
-                    <p>開催期間終了日を下記からひとつ選択してください</p>
+                    <p>開催期間終了日を下記からひとつ選択してください。</p>
                     <p>今日: <span id="today" class="exchange-tody"></span></p>
                     <input type="hidden" id="end_date" name="end_date" value="">
                     <input type="radio" id="radio1" name="finishday" value="1週間後" class="exchange-finishday" onclick="onRadioButtonChange();hihyoji()" checked="checked">1週間後:<span id="after1week"></span><br>
@@ -171,7 +173,7 @@ if (!$holding_flag) {
                     <input type="radio" id="radio5" name="finishday" value="日付選択" class="exchange-finishday" onclick="onRadioButtonChange();hyoji()">日付を選択する（最大4週間）<!--<span id="daycheck">--></span><br>
                 </div>
                 <div id="message" class="daycheck-none">
-                    <input type="date" id="setDate" value='2022-11-30' class="daycheck">
+                    <input type="date" id="setDate" name="end_date" value='<?php echo $onedaylater; ?>' min=<?php echo $onedaylater; ?> max=<?php echo $fourweekslater; ?> class="daycheck">
                 </div>
 
                 <div>

--- a/php/tradeinfo.php
+++ b/php/tradeinfo.php
@@ -106,14 +106,17 @@
                 <!-- 交換会名と開催期間を表示 -->
                 <div class="trade-title">
                     <h1><?php echo $trade_info['trade_name']; ?></h1>
-                    <p><?php echo $trade_info['begin_date']; ?> ～　<?php echo $trade_info['end_date']; ?></p>
+                    <p class="date-title">交換会参加可能期間</p>
+                    <p class="display-date"><?php echo $trade_info['begin_date']; ?> ～　<?php echo $trade_info['end_date']; ?></p>
+                    <p class="date-title">交換実施予定日</p>
+                    <p class="display-date"><?php echo date("Y-m-d", strtotime("+1 day", strtotime($trade_info['end_date']))); ?></p>
                 </div>
 
                 <!-- 参加者のアイコンを表示 -->
                 <div class="participant">
                     <h3>交換会の参加者</h3>
                     <?php if(isset($participant_msg)){ ?>
-                        <div class="prompt_3">
+                        <div class="no-participant">
                             <h4 class="msg-size"><?php echo $participant_msg; ?></h4>
                         </div>
                     <?php }else{ ?>


### PR DESCRIPTION
**確認事項**

- [x] 交換会開催ページで日付選択を行った際に、日付を選択できるか
- [x] 日付選択が最短1日から最長4週間になっているか
- [x] 1~4週間後の選択欄の日付が、前回から1日減らした7日間になっているか
- [x] 開催したあとのtradeinfo.phpのページで、参加期間と交換会実施日が表示されているか、またその表示が開催したものと同じであるか