### PR TITLE
自動ログイン機能の確認

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -103,6 +103,10 @@ body{
     color: rgba(119, 29, 29, 0.534);
 }
 
+.prompt_2 p{
+    font-size: 40px;
+}
+
 .login-form{
     padding: 0 20px;
     margin-top: 120px;
@@ -117,6 +121,15 @@ body{
     margin: auto 0 auto 20px;
     font-size: 50px;
     text-align: left;
+}
+
+.autologin-div{
+    font-size:32px;
+    margin-top: 100px;
+}
+.login{
+    transform: scale(2);
+    margin: 0 6px 0 0;
 }
 
 /* 入力フォーム選択時の枠線 */

--- a/css/login.css
+++ b/css/login.css
@@ -124,12 +124,17 @@ body{
 }
 
 .autologin-div{
-    font-size:32px;
+    font-size: 32px;
     margin-top: 100px;
 }
-.login{
+
+.autologin-div label{
+    display: block;
+}
+
+.autologin {
     transform: scale(2);
-    margin: 0 6px 0 0;
+    margin: 0 20px 0 0;
 }
 
 /* 入力フォーム選択時の枠線 */

--- a/php/classes/user.php
+++ b/php/classes/user.php
@@ -14,7 +14,7 @@
         public function setLoginToken($user_id){
             if(isset($_COOKIE['token'])){
                 $sql = 'delete from user_token where token = ?';
-                $this->exec($sql, array($_COOKIE['token']));
+                $this->exec($sql, [$_COOKIE['token']]);
             }
 
             // 新しいトークンを生成
@@ -22,7 +22,7 @@
             $sql = "select * from user_token where token = ?";
             for($i = 0; $i < 100; $i++) {
                 $token_temp = bin2hex(openssl_random_pseudo_bytes(16));
-                $stmt = $this->query($sql, array($token_temp));
+                $stmt = $this->query($sql, [$token_temp]);
                 if(!$stmt->fetch()) {
                     $token = $token_temp;
                     break;
@@ -159,6 +159,10 @@
         
         // ログアウト処理
         public function logout(){
+            if(isset($_COOKIE['token'])){
+                $sql = 'delete from user_token where token = ?';
+                $this->exec($sql, [$_COOKIE['token']]);
+            }
             $_SESSION = array();
             if (isset($_COOKIE[session_name()])) {
                 //セッションクッキーを削除

--- a/php/classes/user.php
+++ b/php/classes/user.php
@@ -35,7 +35,7 @@
             // テーブルへトークンを保存
             $sql = "insert into user_token(token, userid) values (?, ?)";
             $stmt = $this->exec($sql, [$token, $user_id]);
-            // クッキーへトークンを保存
+            // クッキーへトークンを保存（1週間保持）
             setcookie('token', $token, time() + 60 * 60 * 24 * 7, '/');
         }
 
@@ -169,7 +169,7 @@
                 setcookie(session_name(), '', time() - 42000, '/');
             }
             //自動ログイントークンを削除
-            setcookie('token', '', time()-42000, '/');
+            setcookie('token', '', time() - 42000, '/');
             session_destroy();
         }
     }

--- a/php/login.php
+++ b/php/login.php
@@ -3,6 +3,7 @@
     session_start();
     // user.phpを読み込む
     require_once __DIR__ . '/classes/user.php';
+    $user = new User();
 
     // ログイン中ではないが、クッキーに自動ログイントークンがあった場合
     if(!isset($_SESSION['uid']) && isset($_COOKIE['token'])){
@@ -10,8 +11,8 @@
         if(!empty($result)){
             //ログイン成功したのでセッションIDの振り直しとセッションへユーザーIDをセット
 		    session_regenerate_id(true);
-		    $_SESSION['uid'] = $result['uid'];
-		    $user->setLoginToken($result['uid']);
+		    $_SESSION['uid'] = $result['userid'];
+		    $user->setLoginToken($result['userid']);
             // ホーム画面に遷移する
             header('Location: home.php');
             exit(); 
@@ -23,8 +24,7 @@
         $login_email = $_POST['login_email'];
         $login_pass = $_POST['login_pass'];
 
-        // ユーザーオブジェクトを生成し、「authUser()メソッド」を呼び出し、認証結果を受け取る
-        $user = new User();
+        // 「authUser()メソッド」を呼び出し、認証結果を受け取る
         $result = $user->authUser($login_email);
 
         if(!empty($result)){

--- a/php/login.php
+++ b/php/login.php
@@ -101,8 +101,9 @@
         <input type="password" class="input-form" name="login_pass" maxlenght="64" required>
 
         <div class="autologin-div">
-            <input type="checkbox" id="login" class="login" name="autologin">
-            <label for="login">次回から自動ログイン</label>
+            <label>
+                <input type="checkbox" id="login" class="autologin" name="autologin">次回から自動ログイン
+            </label>
         </div>
 
         <input type="submit" class="btn-login" id="check" name="login" value="ログイン">

--- a/php/login.php
+++ b/php/login.php
@@ -13,17 +13,27 @@
         $user = new User();
         $result = $user->authUser($login_email);
 
-        if(password_verify($login_pass, $result['password'])){  // password_verify関数でハッシュの認証
-            // ユーザー情報をセッションに保存する
-            $_SESSION['uid'] = $result['uid'];
-            $_SESSION['name'] = $result['name'];
-            $_SESSION['comment'] = $result['comment'];
-            $_SESSION['icon'] = $result['icon'];
-            $_SESSION['mailaddress'] = $result['mailaddress'];
-            
-            // ホーム画面に遷移する
-            header('Location: home.php');
-            exit();
+        if(!empty($result)){
+            if(password_verify($login_pass, $result['password'])){  // password_verify関数でハッシュの認証
+                // ユーザー情報をセッションに保存する
+			    session_regenerate_id(true);
+                $_SESSION['uid'] = $result['uid'];
+                $_SESSION['name'] = $result['name'];
+                $_SESSION['comment'] = $result['comment'];
+                $_SESSION['icon'] = $result['icon'];
+                $_SESSION['mailaddress'] = $result['mailaddress'];
+                // 自動ログインにチェックが入っているとき
+                if(isset($_POST['autologin'])){
+                    //自動ログイントークンの生成
+			        $user->setLoginToken($result['uid']);
+                }
+                
+                // ホーム画面に遷移する
+                header('Location: home.php');
+                exit();       
+            }else{
+                $errorMessage = 'メールアドレスとパスワードが<br>正しいか確認してください。';
+            }
         }else{
             $errorMessage = 'メールアドレスとパスワードが<br>正しいか確認してください。';
         }
@@ -76,10 +86,10 @@
         </div>
         <input type="password" class="input-form" name="login_pass" maxlenght="64" required>
 
-        <!-- <div class="autologin-div">
-            <input type="checkbox" id="login" class="login">
+        <div class="autologin-div">
+            <input type="checkbox" id="login" class="login" name="autologin">
             <label for="login">次回から自動ログイン</label>
-        </div> -->
+        </div>
 
         <input type="submit" class="btn-login" id="check" name="login" value="ログイン">
         <br>

--- a/php/login.php
+++ b/php/login.php
@@ -4,6 +4,20 @@
     // user.phpを読み込む
     require_once __DIR__ . '/classes/user.php';
 
+    // ログイン中ではないが、クッキーに自動ログイントークンがあった場合
+    if(!isset($_SESSION['uid']) && isset($_COOKIE['token'])){
+        $result = $user->auto_login();
+        if(!empty($result)){
+            //ログイン成功したのでセッションIDの振り直しとセッションへユーザーIDをセット
+		    session_regenerate_id(true);
+		    $_SESSION['uid'] = $result['uid'];
+		    $user->setLoginToken($result['uid']);
+            // ホーム画面に遷移する
+            header('Location: home.php');
+            exit(); 
+        }
+    }
+
     // ログインボタンが押されたとき
     if(isset($_POST['login'])){
         $login_email = $_POST['login_email'];


### PR DESCRIPTION
**手順**

1. [googleドライブ](https://drive.google.com/file/d/1c8hhHjeZNsw6HBlSwHH4d010XIBknARv/view?usp=share_link)
から、user_tokenテーブルのsqlをそれぞれのデータベースにインポートする。
3. hatyのログイン画面の自動ログインにチェックを入れて、ログインする。
4. ログイン後、そのウインドウを閉じる。（セッションの破棄）
5. もう一度ウインドウを開き、hatyにアクセスする。

**確認事項**

- [x] 手順4を実行したとき、ログイン画面に遷移せず、意図した画面になるか
- [x] 自動ログインにチェックを入れずセッションを破棄した場合、再度hatyにアクセスするとログイン画面に遷移されるか
- [ ] 自動ログインにチェックを入れヘッダーのログアウト後、再度アクセスしてもログイン画面に遷移されるか

**仕組み**
自動ログインにチェック時にトークンを発行し、クッキーとデータベースに保持する。再度アクセスした場合には、クッキーのトークンとデータベースのトークンが同じかを判定し正しければ自動でログイン出来るようにする。クッキー自体にはトークンは1週間保持する。