### PR TITLE
最大文字数の表示を修正しました。

### DIFF
--- a/php/GroupCreate.php
+++ b/php/GroupCreate.php
@@ -28,7 +28,7 @@
             
             header('Location: home.php');
         } else {
-            $errlog = 'パスワードが一致しません';
+            $errlog = 'パスワードが一致しません。<br>パスワードの最大文字数は30文字です。';
         }
     }
 
@@ -45,6 +45,10 @@
         </div>
 
         <h1 class="file-title">グループ作成</h1>
+
+        <div class ="prompt_2">
+            <h4><?= $errlog ?></h4>
+        </div>
 
         <div class="icon-flame" id="icon-flame">
             <img class="icon-img" src="../static/group.png" id="icon-flame2">
@@ -64,7 +68,6 @@
 
         <div class="flex-title">
             <h1 class="input-title">パスワード</h1>
-            <p class="precautions">最大30文字</p>
         </div>
         <div class="must">
             <p class="instructions">パスワードはグループに招待する時に必要になります。<br>忘れないように気を付けてください！</p>
@@ -76,10 +79,6 @@
         </div>
         <div class="must">
             <input class="text-box" type="password" name="group_repass" maxlength="30" required>
-        </div>
-
-        <div class ="prompt_2">
-            <h4><?= $errlog ?></h4>
         </div>
 
 

--- a/php/NewAccount.php
+++ b/php/NewAccount.php
@@ -13,9 +13,9 @@
     // アカウント登録ボタンが押されたとき
     if(isset($_POST['signup'])){
         if(!filter_var($_POST['signup_email'], FILTER_VALIDATE_EMAIL)){     // 入力されたメールアドレスのチェック
-            $errorMessage = "正しいメールアドレスを入力してください。";
+            $errorMessage = "正しいメールアドレスを入力してください。<br> メールアドレスの最大文字数は100文字です。";
         }elseif($_POST['password'] != $_POST['password2']){                 // 入力されたそれぞれのパスワードのチェック
-            $errorMessage = "入力されたパスワードに誤りがあります。";
+            $errorMessage = "入力されたパスワードに誤りがあります。<br>パスワードの最大文字数は64文字です。";
         }else{
             $signup_name = $_POST['signup_name'];
             $signup_email = $_POST['signup_email'];
@@ -99,14 +99,12 @@
             <div>
                 <div class="content-flex">
                     <h1>メールアドレス</h1>
-                    <p>最大100文字</p>
                 </div>
                 <input type="email" class="input-form" name="signup_email" maxlength="100" required>
             </div>
             <div>
                 <div class="content-flex">
                     <h1>パスワード</h1>
-                    <p>最大64文字</p>
                 </div>
                 <input type="password" class="input-form" name="password" maxlength="64" required>
             </div>

--- a/php/exchange_hold.php
+++ b/php/exchange_hold.php
@@ -149,7 +149,6 @@ if (!$holding_flag) {
                 <div>
                     <div class="flex-title">
                         <h1>説明文</h1>
-                        <p>最大400文字</p>
                     </div>
                     <input type="hidden" id="explain_check" name="explain_check" value="Ok">
                     <input class="exchange-exit" type="radio" id="explain-disp" name="explain" onclick="buttonClick_explain()" checked>あり

--- a/php/password_edit.php
+++ b/php/password_edit.php
@@ -17,7 +17,7 @@
     if(isset($_POST['edit_btn'])){
         // 入力された情報をもとに分岐
         if(password_verify($_POST['current_password'], $result['password']) == FALSE){
-            $errorMessage = "入力した現在のパスワードが<br>間違っています。";
+            $errorMessage = "入力した現在のパスワードが<br>間違っています。<br>パスワードの最大文字数は64文字です。";
         }elseif($_POST['new_password1'] != $_POST['new_password2']){
             $errorMessage = "パスワードが一致していません。";
         }elseif($_POST['current_password'] == $_POST['new_password1']){
@@ -40,19 +40,6 @@
 
 <body>
     <div class="password_edit">
-        <!-- エラーメッセージもしくは変更完了メッセージの表示 -->
-        <?PHP if(!empty($errorMessage)){ ?>
-            <div class="prompt_2">
-                <p><?php echo $errorMessage;?></p>
-                <?php $errorMessage =""; ?>
-        </div>
-        <?php }elseif(!empty($completionMessage)){ ?>
-            <div class="prompt_3">
-                <p><?php echo $completionMessage;?></p>
-                <a href="MyPage.php">マイページへ戻る</a>
-                <?php $completionMessage ="";?>
-            </div>
-        <?php } ?>
         <!-- パスワード変更フォーム -->
         <form method="POST" action="" class="password_edit_form">
 
@@ -64,15 +51,26 @@
                 <div class="edit_password_title">
                     <h1 class="pass_title">パスワード変更</h1>
                 </div>
+                <!-- エラーメッセージもしくは変更完了メッセージの表示 -->
+                <?PHP if(!empty($errorMessage)){ ?>
+                    <div class="prompt_2">
+                        <p><?php echo $errorMessage;?></p>
+                        <?php $errorMessage =""; ?>
+                    </div>
+                <?php }elseif(!empty($completionMessage)){ ?>
+                    <div class="prompt_3">
+                        <p><?php echo $completionMessage;?></p>
+                        <a href="MyPage.php">マイページへ戻る</a>
+                        <?php $completionMessage ="";?>
+                    </div>
+                <?php } ?>
                 <div class="password_input">
                     <div class="content-flex">
                         <h1>現在のパスワード</h1>
-                        <p>最大64文字</p>
                     </div>
                     <input type="password" class="edit_password_place" name="current_password" maxlength="64" required>
                     <div class="content-flex">
                         <h1>新しいパスワード</h1>
-                        <p>最大64文字</p>
                     </div>
                     <input type="password" class="edit_password_place" name="new_password1" maxlength="64" required>
                     <div class="content-flex">

--- a/php/profile_edit.php
+++ b/php/profile_edit.php
@@ -100,14 +100,12 @@
                 <div class="edit_input">
                     <div class="flex-content">
                         <h1>メールアドレス</h1>
-                        <p>最大100文字</p>
                     </div>
                     <input type="email" name="email_edit" class="email_edit" maxlength="100" value=<?php echo $result['mailaddress'] ?>>
                 </div>
                 <div class="edit_input">
                     <div class="flex-content">
                         <h1>コメント</h1>
-                        <p>最大400文字</p>
                     </div>
                     <textarea name="comment_edit" class="comment_edit" maxlength="400"><?php echo $result['comment'] ?></textarea>
                 </div>


### PR DESCRIPTION
アカウント作成やパスワード変更画面などの最大文字数の表示を削除しました。
パスワード、メールアドレスの最大文字数表示は削除していますが、ユーザー名や商品名などは最大文字数の表示をそのままにしています。